### PR TITLE
Recreate Missing scrapy.cfg for Scrapy Project

### DIFF
--- a/deep_research/komkom_scraper/scrapy.cfg
+++ b/deep_research/komkom_scraper/scrapy.cfg
@@ -1,0 +1,12 @@
+# scrapy.cfg
+# Cette ligne identifie le dossier comme un projet Scrapy.
+# Ne le supprimez pas !
+
+[settings]
+# L'emplacement de vos paramètres de projet (généralement dans le sous-dossier avec le même nom que le projet).
+default = komkom_scraper.settings
+
+[deploy]
+# Ceci est utilisé par Scrapyd ou d'autres outils de déploiement.
+# Pour le développement local, ce n'est pas strictement nécessaire mais fait partie de la structure du projet.
+project = komkom_scraper


### PR DESCRIPTION
This PR addresses the critical issue of a missing `scrapy.cfg` file in the Scrapy project directory, which was causing the spider to fail with the error 'Scrapy 2.13.2 - no active project'. The `scrapy.cfg` file has been created in the `deep_research/komkom_scraper/` directory with the necessary configuration to recognize the project correctly.

### Changes Made:
- Added a new file `scrapy.cfg` with the following content:

  ```ini
  # scrapy.cfg
  # Cette ligne identifie le dossier comme un projet Scrapy.
  # Ne le supprimez pas !

  [settings]
  # L'emplacement de vos paramètres de projet (généralement dans le sous-dossier avec le même nom que le projet).
  default = komkom_scraper.settings

  [deploy]
  # Ceci est utilisé par Scrapyd ou d'autres outils de déploiement.
  # Pour le développement local, ce n'est pas strictement nécessaire mais fait partie de la structure du projet.
  project = komkom_scraper
  ```

### Verification:
- After confirming that the `scrapy.cfg` file is in place, I executed the command `scrapy list`, which listed the available spiders without any errors.
- Furthermore, I successfully ran the end-to-end script `bash scripts/run_local_e2e.sh`, ensuring the spider operates correctly and the pipeline continues as expected.

---

> This pull request was co-created with Cosine Genie

Original Task: [AutoPM_test/0csnf0tklgr3](https://cosine.sh/ifjbm46juh2l/AutoPM_test/task/0csnf0tklgr3)
Author: Fallou Mbengue

## Summary by Sourcery

Bug Fixes:
- Add scrapy.cfg with project settings and deploy section to restore Scrapy project recognition.