### PR TITLE
Fix Python Version in Local E2E Script

### DIFF
--- a/scripts/run_local_e2e.sh
+++ b/scripts/run_local_e2e.sh
@@ -36,7 +36,7 @@ fi
 
 # --- CREATE TABLES ---
 echo "Creating tables..."
-python deep_research/create_tables.py
+python3 deep_research/create_tables.py
 
 # --- BUILD AND RUN SCRAPER DOCKER ---
 echo "Building komkom_scraper Docker image..."
@@ -53,7 +53,7 @@ docker run --rm \
 
 # --- BUILD EPISODE ---
 echo "Building episode for user 1 (lang=fr)..."
-EPISODE_OUT=$(python scripts/run_episode_builder.py)
+EPISODE_OUT=$(python3 scripts/run_episode_builder.py)
 SUCCESS=$?
 
 if [ $SUCCESS -ne 0 ]; then
@@ -61,5 +61,5 @@ if [ $SUCCESS -ne 0 ]; then
   exit 1
 fi
 
-MP3_PATH=$(echo "$EPISODE_OUT" | python -c "import sys, json; print(json.load(sys.stdin)['mp3_url'])")
+MP3_PATH=$(echo "$EPISODE_OUT" | python3 -c "import sys, json; print(json.load(sys.stdin)['mp3_url'])")
 echo "SUCCESS: Episode built. MP3: $MP3_PATH"


### PR DESCRIPTION
This pull request updates the `run_local_e2e.sh` script to explicitly use `python3` instead of `python`. This change addresses potential issues for users who have only Python 3 installed, resolving errors related to FFmpeg not being executed properly due to Python version conflicts. Specifically, the script modifications ensure that the `create_tables` and `run_episode_builder` Python scripts are run with Python 3, improving compatibility and functionality.

---

> This pull request was co-created with Cosine Genie

Original Task: [AutoPM_test/6lvpt6acayt8](https://cosine.sh/ifjbm46juh2l/AutoPM_test/task/6lvpt6acayt8)
Author: Fallou Mbengue

## Summary by Sourcery

Ensure run_local_e2e.sh invokes Python scripts with python3 to resolve version conflicts and FFmpeg execution errors

Bug Fixes:
- Replace python with python3 for create_tables.py invocation
- Use python3 for run_episode_builder.py execution
- Use python3 for inline JSON parsing command