### PR TITLE
Fix URL for Adepme Spider and Add Wekomkom Spider

### DIFF
--- a/deep_research/komkom_scraper/komkom_scraper/spiders/adepme_spider.py
+++ b/deep_research/komkom_scraper/komkom_scraper/spiders/adepme_spider.py
@@ -4,7 +4,7 @@ from komkom_scraper.items import OpportunityItem
 class AdepmESpider(scrapy.Spider):
     name = 'adepme_spider'
     allowed_domains = ['adepme.sn']
-    start_urls = ['https://www.adepme.sn/opportunites']
+    start_urls = ['https://adepme.sn/opportunites']
 
     def parse(self, response):
         # For each listing article, follow link to detail page

--- a/deep_research/komkom_scraper/komkom_scraper/spiders/wekomkom_spider.py
+++ b/deep_research/komkom_scraper/komkom_scraper/spiders/wekomkom_spider.py
@@ -1,0 +1,89 @@
+import scrapy
+import re
+from komkom_scraper.items import OpportunityItem
+
+class WekomkomSpider(scrapy.Spider):
+    name = 'wekomkom_spider'
+    allowed_domains = ['wekomkom.com']
+    start_urls = ['https://wekomkom.com/accompagnement?tag=opportunite']
+
+    def parse(self, response):
+        # Find all anchors with text "Voir l'offre" or href matching /accompagnement/.+
+        detail_links = set()
+
+        # Anchors with text "Voir l'offre"
+        links_text = response.xpath("//a[contains(normalize-space(text()), \"Voir l'offre\")]/@href").getall()
+        detail_links.update(links_text)
+
+        # Anchors with href matching /accompagnement/.+
+        links_href = response.xpath("//a[re:match(@href, '^/accompagnement/.+')]/@href", namespaces={"re": "http://exslt.org/regular-expressions"}).getall()
+        detail_links.update(links_href)
+
+        for href in detail_links:
+            url = response.urljoin(href)
+            yield scrapy.Request(url, callback=self.parse_opportunity)
+
+        # TODO: Handle infinite scroll / load more (API or dynamic content)
+
+    def parse_opportunity(self, response):
+        def get_text(query):
+            # Try CSS selector first, then XPath if not found
+            res = response.css(query).get()
+            if res:
+                return res.strip()
+            res = response.xpath(query).get()
+            return res.strip() if res else ''
+
+        def get_html(query):
+            htmls = response.css(query).getall()
+            if htmls:
+                return ''.join(htmls).strip()
+            htmls = response.xpath(query).getall()
+            return ''.join(htmls).strip() if htmls else None
+
+        # Title: first h1 or h2 text
+        title = get_text('h1::text') or get_text('h2::text')
+
+        # Description: main article/section outerHTML, fallback to body
+        description = (
+            get_html('article')
+            or get_html('section')
+            or response.xpath('//body').get()
+        )
+
+        # Deadline: pattern "XX jours pour postuler" or time[data-countdown]
+        deadline = None
+        m = re.search(r"(\d+\s+jours\s+pour\s+postuler)", response.text, re.IGNORECASE)
+        if m:
+            deadline = m.group(1)
+        else:
+            countdown = response.xpath("//time[@data-countdown]/@data-countdown").get()
+            if countdown:
+                deadline = countdown
+
+        # Publication date: meta tags
+        publication_date = (
+            response.css('meta[property="article:published_time"]::attr(content)').get()
+            or response.css('meta[name="date"]::attr(content)').get()
+            or response.css('meta[name="pubdate"]::attr(content)').get()
+        )
+
+        opportunity_type = 'Accompagnement'
+        desc_text = description.lower() if description else ""
+        if any(kw in desc_text for kw in ['financement', 'subvention', 'prêt']):
+            opportunity_type = 'Financement'
+        elif any(kw in desc_text for kw in ['formation', 'coaching']):
+            opportunity_type = 'Formation'
+
+        eligibility = None  # Not clearly separated
+
+        yield OpportunityItem(
+            title=title,
+            description=description,
+            deadline=deadline,
+            publication_date=publication_date,
+            opportunity_type=opportunity_type,
+            eligibility=eligibility,
+            link=response.url,
+            source='WEKOMKOM',
+        )

--- a/tests/test_wekomkom_spider.py
+++ b/tests/test_wekomkom_spider.py
@@ -1,0 +1,92 @@
+import pytest
+import scrapy
+from scrapy.http import HtmlResponse, Request
+from komkom_scraper.spiders.wekomkom_spider import WekomkomSpider
+from komkom_scraper.items import OpportunityItem
+
+LIST_PAGE = """
+<html>
+  <body>
+    <section>
+      <a href="/accompagnement/opp-1">Voir l'offre</a>
+      <a href="/accompagnement/opp-2">Voir l'offre</a>
+      <a href="/accompagnement/opp-3/info">Voir l'offre</a>
+      <a href="/autre-page">Autre</a>
+    </section>
+  </body>
+</html>
+"""
+
+DETAIL_PAGE = """
+<html>
+  <head>
+    <meta property="article:published_time" content="2024-05-10" />
+    <meta name="date" content="2024-05-10" />
+  </head>
+  <body>
+    <h1>Super Opportunité Wekomkom</h1>
+    <article>
+      <div>
+        <p>Ceci est la <strong>description</strong> principale.</p>
+        <p>Vous avez 7 jours pour postuler.</p>
+        <p>Bénéficiez d'un financement exceptionnel!</p>
+      </div>
+    </article>
+    <time data-countdown="7 jours pour postuler"></time>
+  </body>
+</html>
+"""
+
+DETAIL_PAGE_FORMATION = """
+<html>
+  <body>
+    <h2>Formation intensive</h2>
+    <section>
+      <p>Cette offre inclut un coaching sur mesure pour PME.</p>
+    </section>
+    <meta name="date" content="2024-04-01" />
+  </body>
+</html>
+"""
+
+@pytest.fixture
+def spider():
+    return WekomkomSpider.from_crawler(scrapy.crawler.Crawler(scrapy.settings.Settings()))
+
+def test_parse_list_page(spider):
+    url = "https://wekomkom.com/accompagnement?tag=opportunite"
+    response = HtmlResponse(url=url, body=LIST_PAGE, encoding='utf-8')
+    results = list(spider.parse(response))
+    reqs = [r for r in results if isinstance(r, Request)]
+    # There should be 3 valid detail links, not the unrelated one
+    assert len(reqs) == 3
+    for r in reqs:
+        assert "/accompagnement/" in r.url
+        assert "autre-page" not in r.url
+
+def test_parse_opportunity(spider):
+    url = "https://wekomkom.com/accompagnement/opp-1"
+    response = HtmlResponse(url=url, body=DETAIL_PAGE, encoding='utf-8')
+    items = list(spider.parse_opportunity(response))
+    assert len(items) == 1
+    item = items[0]
+    assert isinstance(item, OpportunityItem)
+    assert item['title'] == "Super Opportunité Wekomkom"
+    assert "Ceci est la" in item['description']
+    assert item['deadline'] == "7 jours pour postuler"
+    assert item['publication_date'] == "2024-05-10"
+    assert item['opportunity_type'] == "Financement"
+    assert item['eligibility'] is None
+    assert item['link'] == url
+    assert item['source'] == "WEKOMKOM"
+
+def test_parse_opportunity_formation(spider):
+    url = "https://wekomkom.com/accompagnement/opp-formation"
+    response = HtmlResponse(url=url, body=DETAIL_PAGE_FORMATION, encoding='utf-8')
+    items = list(spider.parse_opportunity(response))
+    assert len(items) == 1
+    item = items[0]
+    assert item['title'] == "Formation intensive"
+    assert "coaching" in item['description'].lower()
+    assert item['opportunity_type'] == "Formation"
+    assert item['publication_date'] == "2024-04-01"


### PR DESCRIPTION
This pull request addresses the following changes:

1. **Fix URL in Adepme Spider**: Modified the `start_urls` in `adepme_spider.py` to remove the 'www' from the URL. This helps ensure that requests are sent to the correct endpoint, as it may have caused issues in accessing pages properly.

2. **Add Wekomkom Spider**: Introduced a new spider named `wekomkom_spider` to scrape opportunities from the Wekomkom website. This spider collects links from the main opportunities page and retrieves details from each opportunity page, including the title, description, deadline, publication date, and type of opportunity.

3. **Add Tests for Wekomkom Spider**: Implemented unit tests for the `wekomkom_spider` using `pytest` to ensure that the spider is functioning correctly. The tests cover parsing of the listing and opportunity pages, validating that the expected data is extracted properly.

These changes facilitate improvements in web scraping for both Adepme and Wekomkom platforms, ensuring better functionality and stability.

---

> This pull request was co-created with Cosine Genie

Original Task: [AutoPM_test/uq7a4o7wpvg6](https://cosine.sh/ifjbm46juh2l/AutoPM_test/task/uq7a4o7wpvg6)
Author: Fallou Mbengue

## Summary by Sourcery

Fix the Adepme spider’s start URL and introduce a new Wekomkom spider for scraping opportunity listings with accompanying tests

New Features:
- Add Wekomkom spider to scrape opportunity links and details from the Wekomkom site

Bug Fixes:
- Remove the ‘www’ prefix from the Adepme spider’s start URL to ensure correct page access

Tests:
- Add pytest unit tests to verify Wekomkom spider’s list page parsing and opportunity detail extraction