### PR TITLE
Fix AttributeError in WekomkomSpider Tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -12,3 +12,15 @@ if DEEP_DIR.exists() and str(DEEP_DIR) not in sys.path:
     sys.path.insert(0, str(DEEP_DIR))
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+# --- Ensure scrapy sub-modules are available as attributes -----------------
+import importlib
+try:
+    import scrapy  # noqa: WPS433 (external import inside try is fine here)
+    for _sub in ("crawler", "settings"):
+        if not hasattr(scrapy, _sub):
+            setattr(scrapy, _sub, importlib.import_module(f"scrapy.{_sub}"))
+except ModuleNotFoundError:
+    # Scrapy is an optional dev dependency; the tests that rely on it will
+    # be skipped automatically if it’s not installed.  We don’t enforce it.
+    pass


### PR DESCRIPTION
This pull request addresses the issue encountered while running tests for the `WekomkomSpider` where it raises an `AttributeError` related to missing attributes in the `scrapy` module. 

### Changes made:
1. Modified `conftest.py` to ensure that the `crawler` and `settings` sub-modules of `scrapy` are imported correctly as attributes. This resolves the error of missing attributes and allows the tests to run smoothly.
2. Maintained the existing warning filter for `DeprecationWarning` to prevent irrelevant warnings during the test execution.

By ensuring that the necessary attributes are available, the tests should now pass without exceptions.

---

> This pull request was co-created with Cosine Genie

Original Task: [AutoPM_test/9xqp6wh3f5dk](https://cosine.sh/ifjbm46juh2l/AutoPM_test/task/9xqp6wh3f5dk)
Author: Fallou Mbengue

## Summary by Sourcery

Ensure WekomkomSpider tests no longer fail with AttributeError by injecting missing scrapy submodules in conftest and retaining existing warning filters.

Bug Fixes:
- Stub missing scrapy.crawler and scrapy.settings submodules via importlib to prevent AttributeError in tests.

Enhancements:
- Keep existing DeprecationWarning filter in conftest to suppress irrelevant warnings during test runs.

Chores:
- Catch ModuleNotFoundError to allow tests to skip gracefully when scrapy is not installed.